### PR TITLE
Add a check for empty result

### DIFF
--- a/bq_helper.py
+++ b/bq_helper.py
@@ -76,6 +76,9 @@ class BigQueryHelper(object):
         """
         query_job = self.client.query(query)
         rows = list(query_job.result(timeout=30))
+        if len(rows) == 0:
+            print("Query returned no rows.")
+            return None
         return pd.DataFrame(
             data=[list(x.values()) for x in rows], columns=list(rows[0].keys()))
 


### PR DESCRIPTION
When the query returns nothing, the absence of this check produces a really ugly and unnecessary exception.

```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-59-33c3dea2a858> in <module>()
----> 1 test = dataset.query_to_pandas_safe(query)

/src/bq-helper/bq_helper.py in query_to_pandas_safe(self, query, max_gb_scanned)
     86         query_size = self.estimate_query_size(query)
     87         if query_size <= max_gb_scanned:
---> 88             return self.query_to_pandas(query)
     89         print(f"Query cancelled; estimated size of {query_size} exceeds limit of {max_gb_scanned} GB")
     90 

/src/bq-helper/bq_helper.py in query_to_pandas(self, query)
     78         rows = list(query_job.result(timeout=30))
     79         return pd.DataFrame(
---> 80             data=[list(x.values()) for x in rows], columns=list(rows[0].keys()))
     81 
     82     def query_to_pandas_safe(self, query, max_gb_scanned=1):

IndexError: list index out of range
```